### PR TITLE
Fix class name

### DIFF
--- a/var/spack/repos/builtin/packages/hemepure-gpu/package.py
+++ b/var/spack/repos/builtin/packages/hemepure-gpu/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Hemepuregpu(CMakePackage):
+class HemepureGpu(CMakePackage):
     """HemeLB is a high performance lattice-Boltzmann solver optimized for
     simulating blood flow through sparse geometries, such as those found in the
     human vasculature. It is routinely deployed on powerful supercomputers,


### PR DESCRIPTION
I was getting an error 
```
==> Error: module 'spack.pkg.builtin.hemepure-gpu' has no attribute 'HemepureGpu'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
